### PR TITLE
Add :components directive to ensure engine.lisp loads after other pac…

### DIFF
--- a/scrapycl.asd
+++ b/scrapycl.asd
@@ -18,6 +18,7 @@
                "scrapycl/output/json"
                "scrapycl/output/typed"
                "scrapycl/types")
+  :components ((:file "engine"))
   :in-order-to ((test-op (test-op "scrapycl-tests"))))
 
 


### PR DESCRIPTION
This project follows the :depends-on convention, but I couldn't find a way to delay engine.lisp loading using it.

I also noticed that this issue with engine not being loaded only occurs with the version of scrapycl I got from Ultralisp.
When I tested with a directly cloned repository, I had no issues running the step2 example.
I'm new to CL, so I can't pinpoint the exact cause, but this is the best solution I could come up with.